### PR TITLE
Fixed inconsistency of molecule density & a Basin bug

### DIFF
--- a/src/main/java/com/petrolpark/destroy/chemistry/index/DestroyMolecules.java
+++ b/src/main/java/com/petrolpark/destroy/chemistry/index/DestroyMolecules.java
@@ -188,7 +188,7 @@ public final class DestroyMolecules {
         .id("carbon_dioxide")
         .structure(Formula.deserialize("destroy:linear:O=C=O"))
         .boilingPoint(-78.4645f) // Sublimes, doesn't "boil"
-        .density(1.977f) // Gas density
+        .density(1101) // Liquid density
         .molarHeatCapacity(37.135f)
         .tag(Tags.GREENHOUSE)
         .build(),
@@ -227,7 +227,7 @@ public final class DestroyMolecules {
         .structure(Formula.deserialize("destroy:linear:ClCl"))
         .color(0x20F9FCC2)
         .boilingPoint(-34.04f)
-        .density(3.2f) // Gas density
+        .density(1562.5f) // Liquid density
         .molarHeatCapacity(33.949f)
         .tag(Tags.ACUTELY_TOXIC)
         .tag(Tags.OZONE_DEPLETER)
@@ -245,7 +245,7 @@ public final class DestroyMolecules {
         .id("chlorodifluoromethane")
         .structure(Formula.deserialize("destroy:linear:ClC(F)F"))
         .boilingPoint(-40.7f)
-        .density(3.66f) // Gas density
+        .density(1413f) // Liquid density @ -40.7 C
         .molarHeatCapacity(112.6f)
         .tag(Tags.OZONE_DEPLETER)
         .tag(Tags.REFRIGERANT)
@@ -535,7 +535,7 @@ public final class DestroyMolecules {
     HYDROFLUORIC_ACID = builder()
         .id("hydrofluoric_acid")
         .structure(Formula.deserialize("destroy:linear:FH"))
-        .density(1.15f)
+        .density(1150f) // 48% solution
         .boilingPoint(19.5f)
         // Heat capacity unknown
         .tag(Tags.ACUTELY_TOXIC)
@@ -546,7 +546,7 @@ public final class DestroyMolecules {
         .id("hydrogen")
         .structure(Formula.atom(Element.HYDROGEN).addAtom(Element.HYDROGEN))
         .boilingPointInKelvins(20.271f)
-        .density(70.85f)
+        .density(70.85f) // Liquid H2, Wikipedia
         .molarHeatCapacity(28.84f)
         .build(),
 
@@ -675,7 +675,7 @@ public final class DestroyMolecules {
         .id("methane")
         .structure(Formula.deserialize("destroy:linear:C"))
         .boilingPoint(-161.5f)
-        .density(424f)
+        .density(422.8f) // Liquid, -162C, Wikipedia
         .molarHeatCapacity(35.7f)
         .tag(Tags.GREENHOUSE)
         .tag(Tags.SMOG)
@@ -750,7 +750,7 @@ public final class DestroyMolecules {
                 .addAtom(Element.HYDROGEN)
             ) //TODO maybe add color (though this should come from a decomposition)
         ).boilingPoint(83f)
-        .density(1510f)
+        .density(1513f) // Anhydrous, Wikipedia
         .molarHeatCapacity(53.29f)
         .tag(Tags.ACUTELY_TOXIC)
         .tag(Tags.ACID_RAIN)
@@ -760,7 +760,7 @@ public final class DestroyMolecules {
         .id("nitrogen")
         .structure(Formula.deserialize("destroy:linear:N#N"))
         .boilingPointInKelvins(77.355f)
-        .density(807f)
+        .density(807f) // Liquid, -196C
         .molarHeatCapacity(29.12f)
         .tag(Tags.ABUNDANT_IN_AIR)
         .build(),
@@ -837,7 +837,7 @@ public final class DestroyMolecules {
         .id("oxygen")
         .structure(Formula.deserialize("destroy:linear:O=O"))
         .boilingPointInKelvins(90.188f)
-        .density(1141f)
+        .density(1141f) // Liquid, -183, Wikipedia
         .molarHeatCapacity(29.378f)
         .tag(Tags.ABUNDANT_IN_AIR)
         .build(),

--- a/src/main/java/com/petrolpark/destroy/mixin/BasinCategoryMixin.java
+++ b/src/main/java/com/petrolpark/destroy/mixin/BasinCategoryMixin.java
@@ -17,7 +17,7 @@ import net.minecraft.client.gui.GuiGraphics;
 
 @Mixin(BasinCategory.class)
 public class BasinCategoryMixin {
-    
+
     /**
      * Injection into {@link com.simibubi.create.compat.jei.category.BasinCategory#setRecipe BasinCategory}.
      * Replaces the Blaze Burner icon with a Cooler if needs be, and replaces the Blaze Cake with the cycling {@link com.simibubi.create.AllTags.AllItemTags#BLAZE_BURNER_FUEL_SPECIAL Blaze Burner special fuel tag}.
@@ -42,7 +42,7 @@ public class BasinCategoryMixin {
      */
     @SuppressWarnings("resource")
     @Inject(
-        method = "Lcom/simibubi/create/compat/jei/category/BasinCategory;draw*(Lcom/simibubi/create/content/processing/basin/BasinRecipe;Lmezz/jei/api/gui/ingredient/IRecipeSlotsView;Lnet/minecraft/client/gui/GuiGraphics;DD)V",
+        method = "draw(Lcom/simibubi/create/content/processing/basin/BasinRecipe;Lmezz/jei/api/gui/ingredient/IRecipeSlotsView;Lnet/minecraft/client/gui/GuiGraphics;DD)V",
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/Minecraft;getInstance()Lnet/minecraft/client/Minecraft;" // Injects when it is writing "Heated", "Superheated", etc at the bottom of the screen

--- a/src/main/java/com/petrolpark/destroy/mixin/MechanicalMixerBlockEntityMixin.java
+++ b/src/main/java/com/petrolpark/destroy/mixin/MechanicalMixerBlockEntityMixin.java
@@ -3,6 +3,7 @@ package com.petrolpark.destroy.mixin;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.simibubi.create.content.processing.basin.BasinBlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -25,7 +26,7 @@ import net.minecraftforge.items.IItemHandler;
 public class MechanicalMixerBlockEntityMixin {
     
     /**
-     * Injection into {@link com.simibubi.create.content.contraptions.components.mixer.MechanicalMixerBlockEntity Mechanical Mixers}
+     * Injection into {@link com.simibubi.create.content.kinetics.mixer.MechanicalMixerBlockEntity Mechanical Mixers}
      * to allow them to recognise Mixtures that are able to React.
      * @see com.petrolpark.destroy.recipe.ReactionInBasinRecipe Reactions in Basins
      */

--- a/src/main/java/com/petrolpark/destroy/recipe/ReactionInBasinRecipe.java
+++ b/src/main/java/com/petrolpark/destroy/recipe/ReactionInBasinRecipe.java
@@ -84,14 +84,17 @@ public class ReactionInBasinRecipe extends MixingRecipe {
             Phases phases = mixture.separatePhases(result.amount());
 
             // Add the resultant Mixture to the results for this Recipe
-            FluidStack outputMixtureStack = MixtureFluid.of((int)Math.round(phases.liquidVolume()), phases.liquidMixture());
-            builder.output(outputMixtureStack);
+            // Something left as liquid
+            if (!phases.liquidMixture().isEmpty()) {
+                FluidStack outputMixtureStack = MixtureFluid.of((int)Math.round(phases.liquidVolume()), phases.liquidMixture());
+                builder.output(outputMixtureStack);
 
-            // Let the Player know if the Reaction cannot occur because the output Fluid will not fit
-            if (outputMixtureStack.getAmount() > BASIN_MAX_OUTPUT) {
-                isBasinTooFullToReact = true;
-                canReact = false;
-            };
+                // Let the Player know if the Reaction cannot occur because the output Fluid will not fit
+                if (outputMixtureStack.getAmount() > BASIN_MAX_OUTPUT) {
+                    isBasinTooFullToReact = true;
+                    canReact = false;
+                };
+            }
 
             int duration = Mth.clamp(result.ticks(), 40, 600); // Ensure this takes at least 2 seconds and less than 30 seconds
 


### PR DESCRIPTION
Original molecule density has inconsistency through their phase, most were taken density in the liquid phase, like hydrogen, but some were taken in the gas phase, like chlorine. This makes the game display of concentration of chlorine as 0.0M. Considering that gas density can be calculated based on molar mass (ideal gas), I unified all molecule density to the density of their liquid phase, no matter how low their b.p. is.