### PR TITLE
New mixin for Embeddium support

### DIFF
--- a/src/main/java/com/petrolpark/destroy/mixin/compat/embeddium/WorldSliceMixin.java
+++ b/src/main/java/com/petrolpark/destroy/mixin/compat/embeddium/WorldSliceMixin.java
@@ -1,7 +1,6 @@
 package com.petrolpark.destroy.mixin.compat.embeddium;
 
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
-import net.minecraft.client.color.block.BlockTintCache;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ColorResolver;

--- a/src/main/java/com/petrolpark/destroy/mixin/compat/embeddium/WorldSliceMixin.java
+++ b/src/main/java/com/petrolpark/destroy/mixin/compat/embeddium/WorldSliceMixin.java
@@ -1,0 +1,22 @@
+package com.petrolpark.destroy.mixin.compat.embeddium;
+
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
+import net.minecraft.client.color.block.BlockTintCache;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.ColorResolver;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(WorldSlice.class)
+public class WorldSliceMixin {
+
+    @Shadow @Final public ClientLevel world;
+
+    @Overwrite
+    public int getBlockTint(BlockPos pos, ColorResolver resolver) {
+        return this.world.getBlockTint(pos, resolver);
+    }
+}

--- a/src/main/resources/destroy.mixins.json
+++ b/src/main/resources/destroy.mixins.json
@@ -75,6 +75,7 @@
     "client": [
         "compat.jei.GhostIngredientHandlerMixin",
         "compat.jei.JeiProcessingRecipeMixin",
+        "compat.embeddium.WorldSliceMixin",
         "BeltRendererMixin",
         "ClientLevelMixin",
         "CreativeModeInventoryScreenMixin",


### PR DESCRIPTION
Embeddium's `src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java` has
```
    @Override
    public int getBlockTint(BlockPos pos, ColorResolver resolver) {
        return this.biomeColors.getColor(resolver, pos.getX(), pos.getY(), pos.getZ());
    }
```

Overwrite the change with mixin.

Addresses https://github.com/petrolpark/Destroy/issues/440