### PR TITLE
🏈 Make default smog color resolver natural

### DIFF
--- a/src/main/java/com/petrolpark/destroy/block/color/SmogAffectedBlockColor.java
+++ b/src/main/java/com/petrolpark/destroy/block/color/SmogAffectedBlockColor.java
@@ -18,15 +18,16 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.FoliageColor;
 import net.minecraft.world.level.GrassColor;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraftforge.common.util.LazyOptional;
 
 public class SmogAffectedBlockColor implements BlockColor {
 
-    public static final ColorResolver GRASS_COLOR_RESOLVER = (b, x, z) -> -1;
-    public static final ColorResolver FOLIAGE_COLOR_RESOLVER = (b, x, z) -> -1;
-    public static final ColorResolver WATER_COLOR_RESOLVER = (b, x, z) -> -1;
+    public static final ColorResolver GRASS_COLOR_RESOLVER = Biome::getGrassColor;
+    public static final ColorResolver FOLIAGE_COLOR_RESOLVER = (b, x, z) -> b.getFoliageColor();
+    public static final ColorResolver WATER_COLOR_RESOLVER = (b, x, z) -> b.getWaterColor();
 
     public static final int getAverageGrassColor(BlockAndTintGetter level, BlockPos pos) {
         return level.getBlockTint(pos, GRASS_COLOR_RESOLVER);

--- a/src/main/java/com/petrolpark/destroy/events/DestroyClientModEvents.java
+++ b/src/main/java/com/petrolpark/destroy/events/DestroyClientModEvents.java
@@ -83,7 +83,7 @@ public class DestroyClientModEvents {
      */
     @SubscribeEvent
     public static void registerColorResolvers(RegisterColorHandlersEvent.ColorResolvers event) {
-        event.register(SmogAffectedBlockColor.GRASS_COLOR_RESOLVER);
+        //event.register(SmogAffectedBlockColor.GRASS_COLOR_RESOLVER);
     };
 
     @SubscribeEvent


### PR DESCRIPTION
Partial fix of https://github.com/petrolpark/Destroy/issues/499

Shows non-polluted natural color on DH render and Minimap(Journeymap tested).