### PR TITLE
A minor bugfix

### DIFF
--- a/src/main/resources/data/destroy/recipes/mixing/empty_bomb_bon.json
+++ b/src/main/resources/data/destroy/recipes/mixing/empty_bomb_bon.json
@@ -12,10 +12,10 @@
         "amount": 200
       },
       {
-        "tag": "destroy:explosive/primary"
+        "tag": "destroy:explosives/primary"
       },
       {
-        "tag": "destroy:explosive/secondary"
+        "tag": "destroy:explosives/secondary"
       }
     ],
     "results": [


### PR DESCRIPTION
The tag `destroy:explosive/secondary` was not registered in the code but `destroy:explosives/secondary` was registered and spell similar. EMI says the are no item with the tag of `destroy:explosive/secondary` but there's item with `destroy:explosive:secondary`, also `destroy:explosive/secondary` only appears in this file. All says that that was a major spelling mistake, same with `destroy:explosive/primary`.