### PR TITLE
Fix creative pumps not interacting with pipe networks properly

### DIFF
--- a/src/main/java/com/petrolpark/destroy/mixin/FluidPropagatorMixin.java
+++ b/src/main/java/com/petrolpark/destroy/mixin/FluidPropagatorMixin.java
@@ -1,0 +1,26 @@
+package com.petrolpark.destroy.mixin;
+
+import com.petrolpark.destroy.block.DestroyBlocks;
+import com.simibubi.create.content.fluids.FluidPropagator;
+import com.tterrag.registrate.util.entry.BlockEntry;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(FluidPropagator.class)
+public class FluidPropagatorMixin
+{
+    @Redirect(
+        method="Lcom/simibubi/create/content/fluids/FluidPropagator;propagateChangedPipe(Lnet/minecraft/world/level/LevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/state/BlockState;)V",
+        at=@At(
+            value="INVOKE",
+            target="Lcom/tterrag/registrate/util/entry/BlockEntry;has(Lnet/minecraft/world/level/block/state/BlockState;)Z",
+            remap=false
+        ),
+        remap=false
+    )
+    static private boolean matchOtherPumps(BlockEntry instance, BlockState state) {
+        return instance.has(state) || DestroyBlocks.CREATIVE_PUMP.has(state);
+    }
+}

--- a/src/main/resources/destroy.mixins.json
+++ b/src/main/resources/destroy.mixins.json
@@ -38,6 +38,7 @@
         "FilterItemStackMixin",
         "FluidIngredientMixin",
         "FluidNetworkMixin",
+        "FluidPropagatorMixin",
         "FluidTankBlockEntityMixin",
         "GenericItemFillingMixin",
         "GhostItemMenuMixin",


### PR DESCRIPTION
This fixes Create's pipe networks not recognizing creative pumps, which made them non functional unless they were placed directly adjacent to their source and target.