### PR TITLE
Fix adjusting any Create-like block with a configurable slider causing a right click event to be fired afterwards

### DIFF
--- a/src/main/java/com/petrolpark/destroy/client/gui/screen/BetterValueSettingsScreen.java
+++ b/src/main/java/com/petrolpark/destroy/client/gui/screen/BetterValueSettingsScreen.java
@@ -38,7 +38,7 @@ public class BetterValueSettingsScreen extends ValueSettingsScreen {
     protected void saveAndClose(double mouseX, double mouseY) {
 		ValueSettings closest = getClosestCoordinate((int) mouseX, (int) mouseY);
 		AllPackets.getChannel()
-			.sendToServer(new ValueSettingsPacket(pos, closest.row(), closest.value(), hand, sideAccessed,
+			.sendToServer(new ValueSettingsPacket(pos, closest.row(), closest.value(), null, sideAccessed,
 				AllKeys.ctrlDown()));
 		onClose();
 	};

--- a/src/main/java/com/petrolpark/destroy/mixin/ValueSettingsPacketMixin.java
+++ b/src/main/java/com/petrolpark/destroy/mixin/ValueSettingsPacketMixin.java
@@ -33,6 +33,7 @@ public class ValueSettingsPacketMixin {
 				continue;
 			if (hand != null) {
 				valueSettingsBehaviour.onShortInteract(player, hand, side);
+				return;
 			};
             if (valueSettingsBehaviour instanceof SmartValueSettingsBehaviour smartValueSettingsBehaviour) {
                 smartValueSettingsBehaviour.acceptAccessInformation(hand, side);


### PR DESCRIPTION
Fixes things like Create's pulse repeaters immediately switching to their inverted state after adjusting their delay, or valve handles turning after adjusting their rotation angle, along with settings being forced to their lowest possible value when briefly right clicking a configurable block. This was driving me crazy, for the longest time I thought the Create devs somehow broke something on their end!

This is done by removing the interaction hand from the info sent to the server by `BetterValueSettingsScreen`, since that info is used by Create to detect short right click interactions (when a block is clicked, but not long enough to open the slider pop-up).
I know this is not an ideal fix since you might want some blocks to be configurable via left clicking at some point down the line, but in that case you would need some other way to detect short interactions and handle them regardless of whether the info on the hand used to interact is present or not.