### PR TITLE
Fix KubeJS removing circuit boards from recipes that contain them

### DIFF
--- a/src/main/java/com/petrolpark/destroy/content/processing/trypolithography/recipe/CircuitPatternIngredient.java
+++ b/src/main/java/com/petrolpark/destroy/content/processing/trypolithography/recipe/CircuitPatternIngredient.java
@@ -51,6 +51,9 @@ public class CircuitPatternIngredient extends AbstractIngredient {
     };
 
     @Override
+    public boolean isEmpty() { return false; };
+
+    @Override
     public IIngredientSerializer<CircuitPatternIngredient> getSerializer() {
         return SERIALIZER;
     };


### PR DESCRIPTION
Fixes #638.