### PR TITLE
📝 Update Japanese translation to reflect fix in en_us.json (🐛 Some fixes - da4f6fa)

### DIFF
--- a/src/main/resources/assets/destroy/lang/ja_jp.json
+++ b/src/main/resources/assets/destroy/lang/ja_jp.json
@@ -1174,7 +1174,7 @@
     "destroy.reaction.hypochlorite_formation": "[destroy:hypochlorite]の形成",
     "destroy.reaction.hypochlorite_formation.description": "[destroy:chlorine]を水酸化ナトリウムで{不均化, destroy:disproportionation}する。",
     "destroy.reaction.hypochlorous_acid_dissociation": "[destroy:hypochlorous_acid] 解離",
-    "destroy.reaction.hypochlorous_acid_dissociation.description": "次亜塩素酸は水中で容易に解離しない弱酸です。{塩基, destroy:base}と反応させることで解離を促進できます。",
+    "destroy.reaction.hypochlorous_acid_dissociation.description": "[destroy:hypochlorous_acid]は水中で容易に解離しない弱酸です。{塩基, destroy:base}と反応させることで解離を促進できます。",
     "destroy.reaction.iodide_displacement": "[destroy:iodide]の変位",
     "destroy.reaction.iodide_displacement.description": "[destroy:iodide]の{酸化, destroy:oxidation}と[destroy:chlorine]の{還元, destroy:reduction}。",
     "destroy.reaction.iodine_dissolution": "[destroy:iodine]溶液",


### PR DESCRIPTION
This PR updates a single entry in ja_jp.json to stay consistent with the corresponding fix made in en_us.json as part of the commit titled [🐛 Some fixes.](https://github.com/Petrolpark-Mods/Destroy/commit/da4f6faea606066dc7ef1557fd094d15af5fe67b)
The Japanese version has been updated accordingly.

This change does not alter the in-game displayed text, but ensures structural consistency between language files.

Thank you once again for merging the previous contribution and for the Cunning Linguist Badge — it means a lot! 🌏✨