### PR TITLE
🦐 Fix measuring cylinder crash

### DIFF
--- a/src/main/java/com/petrolpark/destroy/core/chemistry/storage/SimpleMixtureTankRenderer.java
+++ b/src/main/java/com/petrolpark/destroy/core/chemistry/storage/SimpleMixtureTankRenderer.java
@@ -27,7 +27,7 @@ public class SimpleMixtureTankRenderer<T extends SimpleMixtureTankBlockEntity> e
         if (fs.isEmpty()) return;
         Vector3f l = renderInfo.getFluidBoxDimensions().getFirst();
         Vector3f u = renderInfo.getFluidBoxDimensions().getSecond();
-        ForgeCatnipServices.FLUID_RENDERER.renderFluidBox(fs, l.x / 16f, l.y / 16f, l.z / 16f, u.x / 16f, (l.y + (u.y - l.y) * renderInfo.getFluidLevel(container, partialTicks)) / 16f, u.z / 16f, bufferSource.getBuffer(RenderTypes.entityTranslucentBlockMipped()), ms, light, true, true);
+        ForgeCatnipServices.FLUID_RENDERER.renderFluidBox(fs, l.x / 16f, l.y / 16f, l.z / 16f, u.x / 16f, (l.y + (u.y - l.y) * renderInfo.getFluidLevel(container, partialTicks)) / 16f, u.z / 16f, bufferSource, ms, light, true, true);
     };
 
     public static interface ISimpleMixtureTankRenderInformation<C> {


### PR DESCRIPTION
I picked up some mixture with measuring cylinder, and the client crashed. I tried to reconnect, and it constantly crashed.

So I fixed it. Crash report attached.

[crash-2025-07-10_16.01.59-client.txt](https://github.com/user-attachments/files/21156101/crash-2025-07-10_16.01.59-client.txt)
