### PR TITLE
Fix incompatibilities (Caused by ExtendedInventory)

### DIFF
--- a/src/main/java/com/petrolpark/destroy/core/extendedinventory/ExtendedInventory.java
+++ b/src/main/java/com/petrolpark/destroy/core/extendedinventory/ExtendedInventory.java
@@ -70,10 +70,13 @@ public class ExtendedInventory extends Inventory {
     };
 
     public static void refreshPlayerInventoryMenu(Player player, int columns, int invX, int invY, int leftHotbarSlots, int leftHotbarX, int leftHotbarY, int rightHotbarX, int rightHotbarY) {
-        player.inventoryMenu = new InventoryMenu(player.getInventory(), !player.level().isClientSide(), player); // Usually this field would be final; don't tell anybody I did this
+        InventoryMenu oldMenu = player.inventoryMenu;
+        InventoryMenu newMenu = new InventoryMenu(player.getInventory(), !player.level().isClientSide(), player); // Usually this field would be final; don't tell anybody I did this
+        player.inventoryMenu = newMenu;
         get(player).addExtraInventorySlotsToMenu(player.inventoryMenu, columns, invX, invY, leftHotbarSlots, leftHotbarX, leftHotbarY, rightHotbarX, rightHotbarY);
         player.containerMenu = player.inventoryMenu;
         if (player instanceof ServerPlayer sp && sp.containerSynchronizer != null && sp.containerListener != null) sp.initInventoryMenu();
+        newMenu.containerListeners.addAll(oldMenu.containerListeners);
     };
 
     public static void refreshPlayerInventoryMenu(Player player) {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -41,6 +41,7 @@ public net.minecraft.client.gui.screens.advancements.AdvancementTab f_97134_ # r
 public net.minecraft.world.item.alchemy.PotionBrewing f_43494_ # POTION_MIXES
 public net.minecraft.world.item.alchemy.PotionBrewing f_43495_ # CONTAINER_MIXES
 
+public net.minecraft.world.inventory.AbstractContainerMenu f_38848_ # containerListeners
 public net.minecraft.world.inventory.AbstractContainerMenu f_38841_ # lastSlots
 public net.minecraft.world.inventory.AbstractContainerMenu f_150394_ # remoteSlots
 public net.minecraft.world.inventory.AbstractContainerMenu m_38897_(Lnet/minecraft/world/inventory/Slot;)Lnet/minecraft/world/inventory/Slot; # addSlot


### PR DESCRIPTION
Fixes incompatibilities with other mods such as FTB Quests.
These incompatibilities are caused by container listeners not being moved over to the new inventory menu.